### PR TITLE
fix(index.js): avoid creating a new object in reduce loop

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -26,6 +26,8 @@
     // Variables
     "no-use-before-define": [2, "nofunc"],
     "no-unused-vars": [2, {"args": "none"}],
+    // Performance Considerations
+    "no-param-reassign": [0],
     // Stylistic Issues
     "camelcase": [0],
     "no-underscore-dangle": [0],

--- a/src/index.js
+++ b/src/index.js
@@ -69,10 +69,10 @@ ${unused.join(`\n`)}`);
   }
 
   _getFileDepsMap(compilation) {
-    const fileDepsBy = compilation.fileDependencies.reduce((acc, usedFilepath) => ({
-      ...acc,
-      [usedFilepath]: usedFilepath,
-    }), {});
+    const fileDepsBy = compilation.fileDependencies.reduce((acc, usedFilepath) => {
+      acc[usedFilepath] = usedFilepath;
+      return acc;
+    }, {});
 
     const { assets } = compilation;
     Object.keys(assets).forEach(assetRelpath => {


### PR DESCRIPTION
As outlined [here](https://github.com/airbnb/javascript/issues/719), avoiding parameter reassign by creating a new object occasionally can cause performance issues. This happens to be one of those cases! 

This partially reverts e5831867255c8374c77d2e472eae0c69835007e2

Please see below for performance implications for an 1800 module webpack run!

<img width="723" alt="screen shot 2017-06-12 at 9 17 38 am" src="https://user-images.githubusercontent.com/364532/27037796-02d16582-4f57-11e7-994e-c1e1994fc3ac.png">
