### PR TITLE
Add webpack v4 support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ function globOptionsWith(compiler, globOptions) {
 }
 
 function getFileDepsMap(compilation) {
-  const fileDepsBy = compilation.fileDependencies.reduce(
+  const fileDepsBy = [...compilation.fileDependencies].reduce(
     (acc, usedFilepath) => {
       acc[usedFilepath] = true;
       return acc;


### PR DESCRIPTION
webpack v4 uses a `Set` object instead of an `array` here. Spreading the `fileDependencies` into an new array works both for the arrays used by webpack v3 and older, as well as the sets introduced in v4 and moving forward.

Fixes #20