### PR TITLE
Removed additional new line in webpack error/warn

### DIFF
--- a/src/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/__tests__/__snapshots__/index.spec.js.snap
@@ -1,21 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`UnusedFilesWebpackPlugin module deprecated options.pattern should work as expected 1`] = `
-"
-UnusedFilesWebpackPlugin found some unused files:
+"UnusedFilesWebpackPlugin found some unused files:
 src/__tests__/__snapshots__/index.spec.js.snap
 src/__tests__/index.spec.js"
 `;
 
 exports[`UnusedFilesWebpackPlugin module options.patterns should work as expected for a single pattern 1`] = `
-"
-UnusedFilesWebpackPlugin found some unused files:
+"UnusedFilesWebpackPlugin found some unused files:
 src/__tests__/__snapshots__/index.spec.js.snap
 src/__tests__/index.spec.js"
 `;
 
 exports[`UnusedFilesWebpackPlugin module options.patterns should work as expected for an array of patterns 1`] = `
-"
-UnusedFilesWebpackPlugin found some unused files:
+"UnusedFilesWebpackPlugin found some unused files:
 src/__tests__/index.spec.js"
 `;

--- a/src/index.js
+++ b/src/index.js
@@ -43,8 +43,7 @@ async function applyAfterEmit(compiler, compilation, plugin) {
     );
 
     if (unused.length !== 0) {
-      throw new Error(`
-UnusedFilesWebpackPlugin found some unused files:
+      throw new Error(`UnusedFilesWebpackPlugin found some unused files:
 ${unused.join(`\n`)}`);
     }
   } catch (error) {


### PR DESCRIPTION
Comparing to default webpack errors/warns for example when you import uknown dependency there is additional new line char in log.