### PR TITLE
Ensure webpack CLI fails with `failOnUnused`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,9 +48,6 @@ UnusedFilesWebpackPlugin found some unused files:
 ${unused.join(`\n`)}`);
     }
   } catch (error) {
-    if (plugin.options.failOnUnused && compilation.bail) {
-      throw error;
-    }
     const errorsList = plugin.options.failOnUnused
       ? compilation.errors
       : compilation.warnings;


### PR DESCRIPTION
Without this, when using the `--bail` option with webpack CLI will just hang when unused files are detected.

Tested that this works with `webpack-dev-server` still (to prevent [regression](https://github.com/tomchentw/unused-files-webpack-plugin/pull/12)) and that error messages show up.

My hunch is that the [rewrite](https://github.com/tomchentw/unused-files-webpack-plugin/pull/16) addressed in some deeper way how dev server was freezing so that is no longer an issue.