### PR TITLE
Making the file list more prominent in output

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,8 @@ async function applyAfterEmit(compiler, compilation, plugin) {
     if (unused.length !== 0) {
       throw new Error(`
 UnusedFilesWebpackPlugin found some unused files:
-${unused.join(`\n`)}`);
+
+  ${unused.join(`\n  `)}`);
     }
   } catch (error) {
     if (plugin.options.failOnUnused && compilation.bail) {


### PR DESCRIPTION
With the current output, the list of files can be a little difficult to spot. This change adds an extra line break and indents the list by two spaces to make the file list more prominent.

### Current output

```
UnusedFilesWebpackPlugin found some unused files:
src/foo.js
```

### Output with this change

```
UnusedFilesWebpackPlugin found some unused files:

  src/foo.js
```
